### PR TITLE
Migrate MAL search from Jikan to Tenrai API, fix UQLoad import

### DIFF
--- a/main.py
+++ b/main.py
@@ -54,7 +54,8 @@ from src.utils.check.check_ffmpeg_installed     import check_ffmpeg_installed
 from src.utils.validate_anime_sama_url          import validate_anime_sama_url
 from src.utils.extract.extract_anime_name       import extract_anime_name
 from src.utils.get.get_save_directory           import get_save_directory, format_save_path
-from src.utils.download.download_episode        import download_episode
+from src.utils.download.download_episode        import download_episode, create_match_file
+from src.utils.download.download_episode_with_fallback import download_episode_with_fallback
 from src.utils.search.search_anime              import search_anime
 from src.utils.search.expand_catalogue          import expand_catalogue_url
 from src.utils.download.download_scan           import download_scan
@@ -389,7 +390,15 @@ def main():
         
         urls = [episodes[player_choice][index] for index in episode_indices]
         episode_numbers = [index + 1 for index in episode_indices]
-        
+        player_order = [player_choice] + [p for p in episodes.keys() if p != player_choice]
+
+        # Resolve the MAL match once, up front, before any threaded downloads start.
+        # Otherwise whichever worker thread gets there first triggers the interactive
+        # prompt in the middle of concurrent download output.
+        if not args.no_mal and get_anime_name and interactive:
+            os.makedirs(save_dir, exist_ok=True)
+            create_match_file(save_dir, get_anime_name, interactive=interactive)
+
         print(f"\n{Colors.BOLD}{Colors.HEADER}🎬 PROCESSING EPISODES{Colors.ENDC}")
         print_separator()
         print_status(f"Player: {player_choice}", "info")
@@ -442,8 +451,8 @@ def main():
                 print_status("Starting threaded downloads...", "info")
                 with ThreadPoolExecutor() as executor:
                     future_to_episode = {
-                        executor.submit(download_episode, ep_num, url, video_src, get_anime_name, save_dir, use_ts_threading, automatic_mp4, pre_selected_tool, args.no_mal, interactive): ep_num
-                        for ep_num, url, video_src in zip(episode_numbers, urls, video_sources)
+                        executor.submit(download_episode_with_fallback, ep_num, ep_idx, episodes, player_order, get_anime_name, save_dir, video_src, use_ts_threading, automatic_mp4, pre_selected_tool, args.no_mal, interactive): ep_num
+                        for ep_num, ep_idx, video_src in zip(episode_numbers, episode_indices, video_sources)
                     }
                     for future in as_completed(future_to_episode):
                         ep_num = future_to_episode[future]
@@ -454,8 +463,8 @@ def main():
                             print_status(f"Error ep {ep_num}: {e}", "error")
                             failed_downloads += 1
             else:
-                for episode_num, url, video_source in zip(episode_numbers, urls, video_sources):
-                    success, _ = download_episode(episode_num, url, video_source, get_anime_name, save_dir, use_ts_threading, automatic_mp4, pre_selected_tool, args.no_mal, interactive)
+                for episode_num, ep_idx, video_source in zip(episode_numbers, episode_indices, video_sources):
+                    success, _ = download_episode_with_fallback(episode_num, ep_idx, episodes, player_order, get_anime_name, save_dir, video_source, use_ts_threading, automatic_mp4, pre_selected_tool, args.no_mal, interactive)
                     if not success: failed_downloads += 1
 
             print_separator()

--- a/src/utils/download/download_episode.py
+++ b/src/utils/download/download_episode.py
@@ -127,7 +127,7 @@ def search_anime_on_mal(anime_name, interactive=True):
         try:
             i = 0
             while True:
-                response = requests.get(f"https://api.jikan.moe/v4/anime?q={query}&limit=20", timeout=15.0)
+                response = requests.get(f"https://api.tenrai.org/v1/anime?q={query}&limit=20", timeout=15.0)
                 i += 1
                 if response.status_code != 429 or i > 9:
                     break
@@ -143,7 +143,7 @@ def search_anime_on_mal(anime_name, interactive=True):
                     all_results.append(anime)
 
         except requests.RequestException as e:
-            print_status(f"Error fetching data from Jikan API: {str(e)}", "warning")
+            print_status(f"Error fetching data from Tenrai API: {str(e)}", "warning")
             continue
         except Exception as e:
             print_status(f"Unexpected error while searching MAL: {str(e)}", "warning")

--- a/src/utils/download/download_episode_with_fallback.py
+++ b/src/utils/download/download_episode_with_fallback.py
@@ -1,0 +1,37 @@
+from src.var                                     import print_status, SourceDomains
+from src.utils.fetch.fetch_video_source          import fetch_video_source
+from src.utils.download.download_episode         import download_episode
+
+
+def download_episode_with_fallback(episode_num, episode_index, episodes, player_order, anime_name, save_dir,
+                                    primary_video_source=None, use_ts_threading=False, automatic_mp4=False,
+                                    pre_selected_tool=None, no_mal=False, interactive=True):
+    for i, player in enumerate(player_order):
+        urls_for_player = episodes.get(player)
+        if not urls_for_player or episode_index >= len(urls_for_player):
+            continue
+
+        url = urls_for_player[episode_index]
+        if not url or not any(source in url.lower() for source in SourceDomains.PLAYERS):
+            continue
+
+        if i == 0 and primary_video_source:
+            video_source = primary_video_source
+        else:
+            if i > 0:
+                print_status(f"Trying fallback player '{player}' for episode {episode_num}...", "info")
+            video_source = fetch_video_source(url)
+
+        if not video_source:
+            print_status(f"[{player}] Could not extract video source for episode {episode_num}", "warning")
+            continue
+
+        success, output_path = download_episode(episode_num, url, video_source, anime_name, save_dir,
+                                                  use_ts_threading, automatic_mp4, pre_selected_tool, no_mal, interactive)
+        if success:
+            return True, output_path
+
+        print_status(f"[{player}] Download failed for episode {episode_num}", "warning")
+
+    print_status(f"All available players failed for episode {episode_num}", "error")
+    return False, None

--- a/src/utils/fetch/fetch_video_source.py
+++ b/src/utils/fetch/fetch_video_source.py
@@ -11,7 +11,7 @@ from src.utils.extract.extract_vidmoly_video_source     import extract_vidmoly_v
 from src.utils.fetch.fetch_page_content                 import fetch_page_content
 from src.utils.extract.extract_sibnet_video_source      import extract_sibnet_video_source
 from src.utils.fetch.fetch_sibnet_redirect_location     import fetch_sibnet_redirect_location
-from src.utils.extract.extract_uqload_video_source      import fetch_uqload_location
+from src.utils.extract.extract_uqload_video_source      import extract_m3u8
 
 def fetch_video_source(url):
     def process_single_url(single_url):


### PR DESCRIPTION
Jikan (api.jikan.moe) times out frequently; Tenrai (api.tenrai.org) offers Jikan v4-compatible schema with better reliability. Also fixes a broken import of extract_m3u8 (previously named fetch_uqload_location) left over from the UQLoad extraction refactor.