### PR TITLE
Fix MAL matching for French-only anime-sama titles

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,6 +55,7 @@ from src.utils.validate_anime_sama_url          import validate_anime_sama_url
 from src.utils.extract.extract_anime_name       import extract_anime_name
 from src.utils.get.get_save_directory           import get_save_directory, format_save_path
 from src.utils.download.download_episode        import download_episode, create_match_file
+from src.utils.fetch.fetch_alt_titles           import fetch_alt_titles
 from src.utils.download.download_episode_with_fallback import download_episode_with_fallback
 from src.utils.search.search_anime              import search_anime
 from src.utils.search.expand_catalogue          import expand_catalogue_url
@@ -394,7 +395,8 @@ def main():
 
         if not args.no_mal and get_anime_name and interactive:
             os.makedirs(save_dir, exist_ok=True)
-            create_match_file(save_dir, get_anime_name, interactive=interactive)
+            alt_names = fetch_alt_titles(base_url, headers=headers)
+            create_match_file(save_dir, get_anime_name, interactive=interactive, alt_names=alt_names)
 
         print(f"\n{Colors.BOLD}{Colors.HEADER}🎬 PROCESSING EPISODES{Colors.ENDC}")
         print_separator()

--- a/src/utils/download/download_episode.py
+++ b/src/utils/download/download_episode.py
@@ -99,53 +99,66 @@ def _auto_select_by_es_score(results, gap_ratio=2.0):
     return None
 
 
-def search_anime_on_mal(anime_name, interactive=True):
+def search_anime_on_mal(anime_name, interactive=True, alt_names=None):
     cache_key = anime_name.lower().strip()
     if cache_key in _mal_search_cache:
         print_status(f"Using cached MAL data for: {anime_name}", "info")
         return _mal_search_cache[cache_key]
 
-    print_status(f"Searching MAL for: {anime_name}", "info")
+    # MAL's search only understands English/romaji titles. anime-sama URLs
+    # (and thus anime_name) are French, so that query alone usually misses.
+    # alt_names carries the English/romaji names scraped from the anime-sama
+    # page itself, tried in order after the original name.
+    seen = set()
+    queries = []
+    for name in [anime_name] + list(alt_names or []):
+        key = name.lower().strip()
+        if name and key not in seen:
+            seen.add(key)
+            queries.append(name)
 
-    data = _fetch_prefix_json(anime_name, media_type="anime")
-    all_results = _flatten_categories(data, wanted_type="anime")
+    all_results = []
+    for query in queries:
+        print_status(f"Searching MAL for: {query}", "info")
+
+        data = _fetch_prefix_json(query, media_type="anime")
+        results = _flatten_categories(data, wanted_type="anime")
+        if not results:
+            continue
+        all_results = results
+
+        tv_series = [r for r in results if (r.get("payload", {}).get("media_type") or "").lower() in ["tv", "ona"]]
+        other_types = [r for r in results if r not in tv_series]
+
+        name_normalized = normalize(query)
+        for item in tv_series + other_types:
+            if normalize(item.get("name")) == name_normalized:
+                print_status(f"Found exact match: {item['name']}", "success")
+                result = {
+                    "mal_id": item.get("id"),
+                    "title": item.get("name"),
+                    "type": item.get("payload", {}).get("media_type"),
+                }
+                _mal_search_cache[cache_key] = result
+                return result
+
+        auto_match = _auto_select_by_es_score(results)
+        if auto_match:
+            print_status(f"Auto-selected top result: {auto_match['name']}", "success")
+            result = {
+                "mal_id": auto_match.get("id"),
+                "title": auto_match.get("name"),
+                "type": auto_match.get("payload", {}).get("media_type"),
+            }
+            _mal_search_cache[cache_key] = result
+            return result
 
     if not all_results:
         print_status(f"No results found for '{anime_name}'", "warning")
         _mal_search_cache[cache_key] = None
         return None
 
-    tv_series = []
-    other_types = []
-    for item in all_results:
-        media_type = (item.get("payload", {}).get("media_type") or "").lower()
-        if media_type in ["tv", "ona"]:
-            tv_series.append(item)
-        else:
-            other_types.append(item)
-
-    name_normalized = normalize(anime_name)
-    for item in tv_series + other_types:
-        if normalize(item.get("name")) == name_normalized:
-            print_status(f"Found exact match: {item['name']}", "success")
-            result = {
-                "mal_id": item.get("id"),
-                "title": item.get("name"),
-                "type": item.get("payload", {}).get("media_type"),
-            }
-            _mal_search_cache[cache_key] = result
-            return result
-
-    auto_match = _auto_select_by_es_score(all_results)
-    if auto_match:
-        print_status(f"Auto-selected top result: {auto_match['name']}", "success")
-        result = {
-            "mal_id": auto_match.get("id"),
-            "title": auto_match.get("name"),
-            "type": auto_match.get("payload", {}).get("media_type"),
-        }
-        _mal_search_cache[cache_key] = result
-        return result
+    tv_series = [r for r in all_results if (r.get("payload", {}).get("media_type") or "").lower() in ["tv", "ona"]]
 
     if interactive:
         candidates = tv_series if tv_series else all_results
@@ -180,7 +193,7 @@ def search_anime_on_mal(anime_name, interactive=True):
         _mal_search_cache[cache_key] = result
         return result
 
-def create_match_file(save_dir, anime_name, interactive=True):
+def create_match_file(save_dir, anime_name, interactive=True, alt_names=None):
     with _cache_lock:
         try:
             if not anime_name:
@@ -229,7 +242,7 @@ def create_match_file(save_dir, anime_name, interactive=True):
             print(f"{Colors.BOLD}{Colors.HEADER}🔍 Searching for anime on MyAnimeList...{Colors.ENDC}")
             print_separator()
             
-            mal_data = search_anime_on_mal(anime_name, interactive=interactive)
+            mal_data = search_anime_on_mal(anime_name, interactive=interactive, alt_names=alt_names)
             
             if mal_data:
                 with open(match_file_path, 'w', encoding='utf-8') as match_file:

--- a/src/utils/fetch/fetch_alt_titles.py
+++ b/src/utils/fetch/fetch_alt_titles.py
@@ -1,0 +1,28 @@
+import re
+import requests
+
+from src.var import print_status
+
+
+def fetch_alt_titles(base_url, headers=None):
+    """Scrape the English/romaji alternate titles anime-sama shows on an
+    anime's catalogue page (element #titreAlter). MAL's own search only
+    understands those, not the French title used in anime-sama URLs."""
+    match = re.search(r'(https?://[^/]+/catalogue/[^/]+/)', base_url)
+    if not match:
+        return []
+    root_url = match.group(1)
+
+    try:
+        response = requests.get(root_url, headers=headers, timeout=10)
+        response.raise_for_status()
+        html = response.text
+    except requests.RequestException as e:
+        print_status(f"Could not fetch alternate titles: {str(e)}", "warning")
+        return []
+
+    alt_match = re.search(r'id=["\']titreAlter["\'][^>]*>([^<]*)<', html)
+    if not alt_match:
+        return []
+
+    return [title.strip() for title in alt_match.group(1).split(',') if title.strip()]


### PR DESCRIPTION
MAL's search only understands English/romaji titles, but anime-sama URLs (and thus the extracted anime name) are in French, so titles like "Les Carnets de l'Apothicaire" never matched anything on MAL.

Scrape the alternate titles anime-sama already shows on the catalogue page (#titreAlter: English/romaji names) and try each as a fallback MAL search query after the original name, stopping at the first exact/confident match. No third-party anime API involved.